### PR TITLE
Ajustar paleta de colores naranja y negro

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1,8 +1,9 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* Light color scheme: orange background with black text */
+  --background: #ff6f00;
+  --foreground: #000000;
 }
 
 @theme inline {
@@ -14,8 +15,9 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    /* Dark color scheme: black background with orange text */
+    --background: #000000;
+    --foreground: #ff6f00;
   }
 }
 


### PR DESCRIPTION
Update the global color scheme to an orange and black combination.

The user requested a "nice and neat" orange and black color scheme for the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab28cf5d-b54f-4c95-bd58-5f3c35cca8de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab28cf5d-b54f-4c95-bd58-5f3c35cca8de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

